### PR TITLE
Line login v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "laravel/socialite拡張",
 	"license": "MIT",
 	"require": {
-		"laravel/socialite": "^2.0"
+		"laravel/socialite": "^3.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Two/LineProvider.php
+++ b/src/Two/LineProvider.php
@@ -15,12 +15,12 @@ class LineProvider extends AbstractProvider implements ProviderInterface
 
 	protected function getTokenUrl()
 	{
-		return 'https://api.line.me/v1/oauth/accessToken';
+		return 'https://api.line.me/v2/oauth/accessToken';
 	}
 
 	protected function getUserByToken($token)
 	{
-		$response = $this->getHttpClient()->get('https://api.line.me/v1/profile', [
+		$response = $this->getHttpClient()->get('https://api.line.me/v2/profile', [
 			'headers' => [
 				'X-Line-ChannelToken' => $token,
 			],

--- a/src/Two/LineProvider.php
+++ b/src/Two/LineProvider.php
@@ -32,7 +32,7 @@ class LineProvider extends AbstractProvider implements ProviderInterface
 	protected function mapUserToObject(array $user)
 	{
 		return (new User())->setRaw($user)->map([
-			'id'     => $user['mid'],
+			'id'     => $user['userId'],
 			'name'   => $user['displayName'],
 			'avatar' => $user['pictureUrl'],
 		]);


### PR DESCRIPTION
LINE Login バージョン 2 に対応してみました。
ユーザーごとのIDが、mid ではなく userId に変更になっています。（値も変わっています）
https://business.line.me/ja/news/20057478

また、laravel 5.4 へのバージョンアップにともない、laravel/socialite が 2.0 から 3.0 になったので、composer.json もそれに書き換えています。
